### PR TITLE
fix: requirements for run_demo.sh

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,6 +15,7 @@ pre-commit
 pycocoevalcap
 pycocotools
 python-magic
+scikit-image
 streamlit
 timm==0.4.12
 torch==1.10.0


### PR DESCRIPTION
Added scipy and scikit-image as dependencies. Solves https://github.com/salesforce/LAVIS/issues/12