### PR TITLE
fix: `gpt_dialogue` loading issue

### DIFF
--- a/lavis/models/gpt_models/gpt_dialogue.py
+++ b/lavis/models/gpt_models/gpt_dialogue.py
@@ -15,7 +15,7 @@ from transformers.modeling_outputs import CausalLMOutputWithCrossAttentions
 
 
 @registry.register_model("gpt_dialogue")
-class GPTDialogue(GPT2LMHeadModel, BaseModel):
+class GPTDialogue(BaseModel, GPT2LMHeadModel):
 
     PRETRAINED_MODEL_CONFIG_DICT = {"base": "configs/models/gpt_dialogue_base.yaml"}
 
@@ -105,6 +105,6 @@ class GPTDialogue(GPT2LMHeadModel, BaseModel):
 
     @classmethod
     def from_config(cls, cfg):
-        model = cls.from_pretrained("gpt2", len_video_ft=cfg["len_video_ft"])
+        model = cls.__bases__[1].from_pretrained("gpt2")
         model.resize_token_embeddings(cfg["len_tokenizer"])
         return model


### PR DESCRIPTION
Trying to solve https://github.com/salesforce/LAVIS/issues/14

Since the `GPTDialogue` has `GPT2LMHeadModel` as the first parent
https://github.com/salesforce/LAVIS/blob/c2b5b2f492f546c55e3a1dccd36418628806c5d4/lavis/models/gpt_models/gpt_dialogue.py#L18
the following line was causing an MRO issue
https://github.com/salesforce/LAVIS/blob/c2b5b2f492f546c55e3a1dccd36418628806c5d4/lavis/models/__init__.py#L173 
It was calling `transformers.modelling_utils.PreTrainedModel.from_pretrained`, (`PreTrainedModel` is a parent of `GPT2LMHeadModel`)  and has different interface than `lavis.models.base_models.BaseModel.from_pretrained`

--- 
I've swapped the parents. It resolved the issue in `model = model_cls.from_pretrained(model_type=model_type)` and created an issue inside `GPTDialogue.from_config`. I've fixed this one by specifying the MRO.

---
Unfortunately, `len_video_ft` was still throwing errors. I didn't find the usage of `len_video_ft` parameter outside of `GPTDialogue` class, so I've removed it from https://github.com/salesforce/LAVIS/blob/c2b5b2f492f546c55e3a1dccd36418628806c5d4/lavis/models/gpt_models/gpt_dialogue.py#L108
This way, `load_model_and_preprocess(name="gpt_dialogue", model_type="base", is_eval=True, device=device)` worked without errors, but I didn't test if it works as intended (wish there were unit tests)
Feel free to edit this PR