### PR TITLE
Fix git url for git clone in documentation

### DIFF
--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -89,7 +89,7 @@ Installation
 
 .. code-block:: bash
 
-   git clone https://github.com/MetaMind/LAVIS.git
+   git clone https://github.com/salesforce/LAVIS.git
    cd LAVIS
    pip install .
 


### PR DESCRIPTION
The git url for git clone in documentation is not working, it's not the Salesforce repository.