### PR TITLE
Fix error failling VQA evaluation

### DIFF
--- a/lavis/configs/datasets/coco/defaults_vqa.yaml
+++ b/lavis/configs/datasets/coco/defaults_vqa.yaml
@@ -23,8 +23,8 @@ datasets:
               # TODO make this order insensitive
               - https://storage.googleapis.com/sfr-vision-language-research/LAVIS/datasets/vqav2/vqa_val_eval.json
               - https://storage.googleapis.com/sfr-vision-language-research/LAVIS/datasets/vqav2/answer_list.json
-              - https://storage.googleapis.com/sfr-vision-language-research/LAVIS/datasets/vqav2/v2_mscoco_val2014_annotations.json
               - https://storage.googleapis.com/sfr-vision-language-research/LAVIS/datasets/vqav2/v2_OpenEnded_mscoco_val2014_questions.json
+              - https://storage.googleapis.com/sfr-vision-language-research/LAVIS/datasets/vqav2/v2_mscoco_val2014_annotations.json
           storage:
               - coco/annotations/vqa_val_eval.json
               - coco/annotations/answer_list.json


### PR DESCRIPTION
When we run
```
run_scripts/blip/eval/validate_vqa.sh
```
after
```
run_scripts/blip/train/train_vqa.sh
```
because `defaults_vqa.yaml` in `lavis/configs/datasets/coco` 
downloads `v2_OpenEnded_mscoco_val2014_questions.json` to `v2_mscoco_val2014_annotations.json`and downloads `v2_mscoco_val2014_annotations.json` to `v2_OpenEnded_mscoco_val2014_questions.json`.
