### PR TITLE
fix missing image in get_item function

### DIFF
--- a/lavis/datasets/datasets/avsd_dialogue_datasets.py
+++ b/lavis/datasets/datasets/avsd_dialogue_datasets.py
@@ -4,7 +4,7 @@
  SPDX-License-Identifier: BSD-3-Clause
  For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
 """
-
+import random
 import torch
 from lavis.datasets.datasets.dialogue_datasets import (
     DialogueDataset,
@@ -22,14 +22,18 @@ class AVSDDialDataset(DialogueDataset):
         super().__init__(vis_processor, text_processor, vis_root, ann_paths)
 
     def __getitem__(self, index):
+        availabile = False
+        while not availabile:
+            try:
+                ann = self.annotation[index]
+                vname = ann["image_id"]
+                video = self.vis_processor(self.vis_root, vname)
+                dialogue = self.text_processor(ann)
+                availabile = True
 
-        ann = self.annotation[index]
-
-        vname = ann["image_id"]
-
-        video = self.vis_processor(self.vis_root, vname)
-
-        dialogue = self.text_processor(ann)
+            except Exception as e:
+                print(f"Error while read file idx {index} in  {e}")
+                index = random.randint(0, len(self.annotation) - 1)
 
         # "image_id" is kept to stay compatible with the COCO evaluation format
         return {
@@ -99,15 +103,21 @@ class AVSDDialEvalDataset(DialogueEvalDataset):
         super().__init__(vis_processor, text_processor, vis_root, ann_paths)
 
     def __getitem__(self, index):
+        availabile = False
+        while not availabile:
+            try:
+                ann = self.annotation[index]
 
-        ann = self.annotation[index]
+                vname = ann["image_id"]
 
-        vname = ann["image_id"]
+                video = self.vis_processor(self.vis_root, vname)
 
-        video = self.vis_processor(self.vis_root, vname)
+                dialogue = self.text_processor(ann)
 
-        dialogue = self.text_processor(ann)
-
+                availabile = True
+            except Exception as e:
+                print(f"Error while read file idx {index} in  {e}")
+                index = random.randint(0, len(self.annotation) - 1)
         # "image_id" is kept to stay compatible with the COCO evaluation format
         return {
             "video_fts": video["video_fts"],

--- a/lavis/datasets/datasets/coco_caption_datasets.py
+++ b/lavis/datasets/datasets/coco_caption_datasets.py
@@ -7,6 +7,7 @@
 
 import os
 import json
+import random
 
 from PIL import Image
 from PIL import ImageFile
@@ -28,14 +29,21 @@ class COCOCapEvalDataset(CaptionEvalDataset):
         super().__init__(vis_processor, text_processor, vis_root, ann_paths)
 
     def __getitem__(self, index):
-        ann = self.annotation[index]
+        availabile = False
+        while not availabile:
+            try:
+                ann = self.annotation[index]
 
-        image_path = os.path.join(self.vis_root, ann["image"])
-        image = Image.open(image_path).convert("RGB")
+                image_path = os.path.join(self.vis_root, ann["image"])
+                image = Image.open(image_path).convert("RGB")
 
-        image = self.vis_processor(image)
+                image = self.vis_processor(image)
+                img_id = ann["image"].split("/")[-1].strip(".jpg").split("_")[-1]
 
-        img_id = ann["image"].split("/")[-1].strip(".jpg").split("_")[-1]
+                availabile = True
+            except Exception as e:
+                print(f"Error while read file idx {index} in  {e}")
+                index = random.randint(0, len(self.annotation) - 1)
 
         return {
             "image": image,
@@ -54,14 +62,21 @@ class NoCapsEvalDataset(CaptionEvalDataset):
         super().__init__(vis_processor, text_processor, vis_root, ann_paths)
 
     def __getitem__(self, index):
-        ann = self.annotation[index]
+        availabile = False
+        while not availabile:
+            try:
+                ann = self.annotation[index]
 
-        image_path = os.path.join(self.vis_root, ann["image"])
-        image = Image.open(image_path).convert("RGB")
+                image_path = os.path.join(self.vis_root, ann["image"])
+                image = Image.open(image_path).convert("RGB")
 
-        image = self.vis_processor(image)
+                image = self.vis_processor(image)
+                img_id = ann["img_id"]
 
-        img_id = ann["img_id"]
+                availabile = True
+            except Exception as e:
+                print(f"Error while read file idx {index} in  {e}")
+                index = random.randint(0, len(self.annotation) - 1)
 
         return {
             "image": image,


### PR DESCRIPTION
Sometimes, when the "**__getitem__**" function is called, the whole program may stop because the image doesn't exist or for some other problem. I tried to fix this according to the following methods, and it works. However, since there are a lot of datasets in this repo, if I use **this same code** in each dataset, it will be very redundant. I wonder if you have any good solution.
```
def __getitem__(self, index):
    availabile = False
    while not availabile:
        try:
            ann = self.annotation[index]

            image_path = os.path.join(self.vis_root, ann["image"])
            image = Image.open(image_path).convert("RGB")

            image = self.vis_processor(image)
            img_id = ann["image"].split("/")[-1].strip(".jpg").split("_")[-1]

            availabile = True
        except Exception as e:
            print(f"Error while read file idx {index} in  {e}")
            index = random.randint(0, len(self.annotation) - 1)

    return {
        "image": image,
        "image_id": img_id,
        "instance_id": ann["instance_id"],
    }
```