### PR TITLE
Fix requirements file

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -19,9 +19,11 @@ scikit-image
 streamlit
 timm==0.4.12
 torch==1.10.0
-torchvision
+torchvision==0.11.1
 tqdm
 transformers>=4.15.0,<4.22.0
 webdataset
 wheel
 sentencepiece
+spacy
+pydantic==1.10.2


### PR DESCRIPTION
The requirements file was not updated, casing a few small issues when running `pip install -e .` and trying to run the demo.

1. `torchvision` version is not specified, thus pip tries to install the latest version which is not compatible with torch 1.10.0,  added `torchvision==0.11.1` to the requirements file which is the compatible version.
2.  The script`lavis/models/img2prompt_models/img2prompt_vqa.py` requires `spacy`, but it was not reflected in the requirements file resulting in an import error when running the demo, added `spacy` to the requirement file.
3. `spacy` requires a specific version of `pydantic`, see issue in `spacy` repo [here](https://github.com/explosion/spaCy/issues/12034), added `pydantic==1.10.2` to the requirements file. 

Overall small changes, but hopefully it will save a 10 minutes of debugging to the next person:)

