### PR TITLE
added requiered spacy model

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@
  SPDX-License-Identifier: BSD-3-Clause
  For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
 """
+import os
 
 from setuptools import setup, find_namespace_packages
 import platform
@@ -34,3 +35,5 @@ setup(
     dependency_links=DEPENDENCY_LINKS,
     zip_safe=False,
 )
+
+os.system('python -m spacy download en_core_web_sm')


### PR DESCRIPTION
Apart from `spacy` VQA also requires `en_core_web_sm ` model.
This PR is meant to be merged alongside with https://github.com/salesforce/LAVIS/pull/75, but is separated from it since it's a bit hacky. Still solves the problem though.