### PR TITLE
Update requirements-dev.txt

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,7 +18,7 @@ python-magic
 scikit-image
 streamlit
 timm==0.4.12
-torch==1.10.0
+torch
 torchvision
 tqdm
 transformers>=4.15.0,<4.22.0


### PR DESCRIPTION
When installing by pip, the 1.10.0 version of torch breaks the code since other packages are not compatible. Leaving torch without specifying a version solves this, since it downloads the most recent pip version that is 1.13