### PR TITLE
Small link fix: Update Google Colab link img2prompt -> blip2

### DIFF
--- a/projects/blip2/README.md
+++ b/projects/blip2/README.md
@@ -12,7 +12,7 @@ or install from source following LAVIS instruction.
 ### Demo:
 Try out the Web Demo! [![Hugging Face Spaces](https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-Spaces-blue)](https://huggingface.co/spaces/Salesforce/BLIP2)
 
-Try out our [Notebook Demo](https://github.com/salesforce/LAVIS/blob/main/examples/blip2_instructed_generation.ipynb) on instructed vision-to-language generation: [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/salesforce/LAVIS/blob/main/projects/img2prompt-vqa/img2prompt_vqa.ipynb)
+Try out our [Notebook Demo](https://github.com/salesforce/LAVIS/blob/main/examples/blip2_instructed_generation.ipynb) on instructed vision-to-language generation: [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/salesforce/LAVIS/blob/main/examples/blip2_instructed_generation.ipynb)
 
 
 ### BLIP-2 Model Zoo 


### PR DESCRIPTION
Hi there,

Big fan of the LAVIS library!

Just fixing a link in the BLIP-2 project page.

Previous link leads to img2prompt notebook rather than BLIP-2.

Before: https://colab.research.google.com/github/salesforce/LAVIS/blob/main/projects/img2prompt-vqa/img2prompt_vqa.ipynb

After: https://colab.research.google.com/github/salesforce/LAVIS/blob/main/examples/blip2_instructed_generation.ipynb