### PR TITLE
added clip models vocab file to manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,3 +5,4 @@ recursive-exclude lavis/datasets/download_scripts *
 recursive-exclude lavis/output *
 
 include requirements.txt
+include lavis/models/clip_models/bpe_simple_vocab_16e6.txt.gz


### PR DESCRIPTION
Hey :smile: , when installing lavis via pip the clip vocab file `bpe_simple_vocab_16e6.txt.gz` is missing and therefore throwing an error `FileNotFoundError: [Errno 2] No such file or directory: '/home/maxi/ml/test-lavis/venv/lib/python3.10/site-packages/lavis/models/clip_models/bpe_simple_vocab_16e6.txt.gz'`. I added the file to the MANIFEST.in - same as in https://github.com/mlfoundations/open_clip/blob/1c8647f14ff1f826b9096962777e39f7c5cd4ba9/MANIFEST.in - to include it in future releases.