### PR TITLE
Fix command path in docs

### DIFF
--- a/docs/tutorial.configs.rst
+++ b/docs/tutorial.configs.rst
@@ -8,7 +8,7 @@ To replicate the experiments, just run these bash scripts. For example, to train
 
 .. code-block::
 
-    bash run_scripts/lavis/blip/train/train_retrieval_coco.sh
+    bash run_scripts/blip/train/train_retrieval_coco.sh
 
 Inside the scripts, we can see 
 

--- a/docs/tutorial.evaluation.rst
+++ b/docs/tutorial.evaluation.rst
@@ -31,10 +31,10 @@ To evaluate pre-trained model, simply run
 
 .. code-block:: bash
 
-    bash run_scripts/lavis/blip/eval/eval_coco_cap.sh
+    bash run_scripts/blip/eval/eval_coco_cap.sh
 
 Or to evaluate a large model:
 
 .. code-block:: bash
 
-    bash run_scripts/lavis/blip/eval/eval_coco_cap_large.sh
+    bash run_scripts/blip/eval/eval_coco_cap_large.sh

--- a/docs/tutorial.evaluation.rst
+++ b/docs/tutorial.evaluation.rst
@@ -12,7 +12,7 @@ most of the public dataset, to download MSCOCO dataset, simply run
 
 .. code-block:: bash
 
-    cd lavis/datasets/download_scripts && bash download_coco.py
+    cd lavis/datasets/download_scripts && python download_coco.py
 
 This will put the downloaded dataset at a default cache location ``cache`` used by LAVIS.
 

--- a/docs/tutorial.training-example.rst
+++ b/docs/tutorial.training-example.rst
@@ -7,7 +7,7 @@ To finetune the model, we have prepared a run script for you, which can run as f
 
 .. code-block:: bash
 
-    bash run_scripts/lavis/blip/train/train_caption_coco_large.sh
+    bash run_scripts/blip/train/train_caption_coco_large.sh
 
 This will finetune the pre-trained BLIP large model into a new model that can be used for captioning.
 


### PR DESCRIPTION
Currently, `train_caption_coco_large.sh` is not located on `run_scripts/lavis/blip/...` but `run_scripts/blip/...`.
I found 4 cases hits, so fixed them.
```
awkrail@taichi-nishimuranoMacBook-Pro docs % ag "run_scripts/lavis"
tutorial.training-example.rst
10:    bash run_scripts/lavis/blip/train/train_caption_coco_large.sh

tutorial.configs.rst
11:    bash run_scripts/lavis/blip/train/train_retrieval_coco.sh

tutorial.evaluation.rst
34:    bash run_scripts/lavis/blip/eval/eval_coco_cap.sh
40:    bash run_scripts/lavis/blip/eval/eval_coco_cap_large.sh
```