### PR TITLE
fix max_txt_len typos in blip2_t5 model

### DIFF
--- a/lavis/models/blip2_models/blip2_t5.py
+++ b/lavis/models/blip2_models/blip2_t5.py
@@ -119,14 +119,14 @@ class Blip2T5(Blip2Base):
                 samples["text_input"],
                 padding="longest",
                 truncation=True,
-                max_length=self.max_text_length,
+                max_length=self.max_txt_len,
                 return_tensors="pt",
             ).to(image.device)
             output_tokens = self.t5_tokenizer(
                 samples["text_output"],
                 padding="longest",
                 truncation=True,
-                max_length=self.max_text_length,
+                max_length=self.max_txt_len,
                 return_tensors="pt",
             ).to(image.device)
 


### PR DESCRIPTION
fix max_txt_len typos. 

Besides, the default `max_txt_len` of blip2_t5 and blip2_opt is just `32`, is it a fine value for max caption length?