### PR TITLE
torch version >=1.12.0 to be compatible with torch.amp.autocast

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ sentencepiece
 spacy
 streamlit
 timm==0.4.12
-torch>=1.10.0
+torch>=1.12.0
 torchvision
 tqdm
 transformers>=4.25.0,<4.27


### PR DESCRIPTION
Hi, `torch.amp.autocast` is used in the [BLIP2-T5 model](https://github.com/salesforce/LAVIS/blob/7aa83e93003dade66f7f7eaba253b10c459b012d/lavis/models/blip2_models/blip2_t5.py#L218), while this API is added in [PyTorch 1.12.0+](https://discuss.pytorch.org/t/module-torch-has-no-attribute-amp/172026/2). 

An updated requirement for the torch version may be needed, not only to solve the current bugs, also for compatibility with future advanced functions.