### PR TITLE
demo app update streamlit caching version

### DIFF
--- a/app/caption.py
+++ b/app/caption.py
@@ -66,7 +66,7 @@ def app():
             model=model, image=img, use_nucleus_sampling=not use_beam
         )
 
-        col2.write("\n\n".join(captions), use_column_width=True)
+        col2.write("\n\n".join(captions))
 
 
 def generate_caption(

--- a/app/classification.py
+++ b/app/classification.py
@@ -19,7 +19,7 @@ from app.utils import load_blip_itm_model
 from lavis.processors.clip_processors import ClipImageEvalProcessor
 
 
-@st.cache()
+@st.cache_data
 def load_demo_image(img_url=None):
     if not img_url:
         img_url = "https://img.atlasobscura.com/yDJ86L8Ou6aIjBsxnlAy5f164w1rjTgcHZcx2yUs4mo/rt:fit/w:1200/q:81/sm:1/scp:1/ar:1/aHR0cHM6Ly9hdGxh/cy1kZXYuczMuYW1h/em9uYXdzLmNvbS91/cGxvYWRzL3BsYWNl/X2ltYWdlcy85MDll/MDRjOS00NTJjLTQx/NzQtYTY4MS02NmQw/MzI2YWIzNjk1ZGVk/MGZhMTJiMTM5MmZi/NGFfUmVhcl92aWV3/X29mX3RoZV9NZXJs/aW9uX3N0YXR1ZV9h/dF9NZXJsaW9uX1Bh/cmssX1NpbmdhcG9y/ZSxfd2l0aF9NYXJp/bmFfQmF5X1NhbmRz/X2luX3RoZV9kaXN0/YW5jZV8tXzIwMTQw/MzA3LmpwZw.jpg"
@@ -27,14 +27,7 @@ def load_demo_image(img_url=None):
     return raw_image
 
 
-@st.cache(
-    hash_funcs={
-        torch.nn.parameter.Parameter: lambda parameter: parameter.data.detach()
-        .cpu()
-        .numpy()
-    },
-    allow_output_mutation=True,
-)
+@st.cache_resource
 def load_model_cache(model_type, device):
     if model_type == "blip":
         model = load_model(

--- a/app/dataset_browser.py
+++ b/app/dataset_browser.py
@@ -80,7 +80,7 @@ def gather_items(samples, exclude=[]):
     return gathered
 
 
-@st.cache(allow_output_mutation=True)
+@st.cache_data
 def load_dataset_cache(name):
     return load_dataset(name)
 

--- a/app/image_text_match.py
+++ b/app/image_text_match.py
@@ -74,7 +74,7 @@ def app():
         qry_tok = tokenizer(qry, return_tensors="pt").to(device)
         gradcam, output = compute_gradcam(model, img, qry, qry_tok, block_num=layer_num)
 
-        avg_gradcam = getAttMap(norm_img, gradcam[0][1], blur=True)
+        avg_gradcam = getAttMap(norm_img, gradcam[0][1].numpy(), blur=True)
 
         col2.image(avg_gradcam, use_column_width=True, clamp=True)
         # output = model(img, question)

--- a/app/multimodal_search.py
+++ b/app/multimodal_search.py
@@ -23,14 +23,7 @@ from lavis.models import load_model
 from lavis.processors import load_processor
 
 
-@st.cache(
-    hash_funcs={
-        torch.nn.parameter.Parameter: lambda parameter: parameter.data.detach()
-        .cpu()
-        .numpy()
-    },
-    allow_output_mutation=True,
-)
+@st.cache_data
 def load_feat():
     from lavis.common.utils import download_url
 
@@ -50,14 +43,7 @@ def load_feat():
     return path2feat, paths, all_img_feats
 
 
-@st.cache(
-    hash_funcs={
-        torch.nn.parameter.Parameter: lambda parameter: parameter.data.detach()
-        .cpu()
-        .numpy()
-    },
-    allow_output_mutation=True,
-)
+@st.cache_resource
 def load_feature_extractor_model(device):
     model_url = "https://storage.googleapis.com/sfr-vision-language-research/BLIP/models/model_base.pth"
 

--- a/app/text_localization.py
+++ b/app/text_localization.py
@@ -73,7 +73,7 @@ def app():
 
         gradcam, _ = compute_gradcam(model, img, qry, qry_tok, block_num=layer_num)
 
-        avg_gradcam = getAttMap(norm_img, gradcam[0][1], blur=True)
+        avg_gradcam = getAttMap(norm_img, gradcam[0][1].numpy(), blur=True)
         col2.image(avg_gradcam, use_column_width=True, clamp=True)
 
         num_cols = 4.0
@@ -93,7 +93,7 @@ def app():
                     gradcam_img = next(gradcam_iter)
 
                     word = tokenizer.decode([token_id])
-                    gradcam_todraw = getAttMap(norm_img, gradcam_img, blur=True)
+                    gradcam_todraw = getAttMap(norm_img, gradcam_img.numpy(), blur=True)
 
                     new_title = (
                         '<p style="text-align: center; font-size: 25px;">{}</p>'.format(

--- a/app/utils.py
+++ b/app/utils.py
@@ -28,19 +28,12 @@ def read_img(filepath):
     return raw_image
 
 
-@st.cache(
-    hash_funcs={
-        torch.nn.parameter.Parameter: lambda parameter: parameter.data.detach()
-        .cpu()
-        .numpy()
-    },
-    allow_output_mutation=True,
-)
+@st.cache_resource
 def load_model_cache(name, model_type, is_eval, device):
     return load_model(name, model_type, is_eval, device)
 
 
-@st.cache(allow_output_mutation=True)
+@st.cache_resource
 def init_bert_tokenizer():
     tokenizer = BlipBase.init_tokenizer()
     return tokenizer
@@ -66,14 +59,7 @@ def getAttMap(img, attMap, blur=True, overlap=True):
     return attMap
 
 
-@st.cache(
-    hash_funcs={
-        torch.nn.parameter.Parameter: lambda parameter: parameter.data.detach()
-        .cpu()
-        .numpy()
-    },
-    allow_output_mutation=True,
-)
+@st.cache_resource
 def load_blip_itm_model(device, model_type="base"):
     model = load_model(
         "blip_image_text_matching", model_type, is_eval=True, device=device

--- a/app/vqa.py
+++ b/app/vqa.py
@@ -60,4 +60,4 @@ def app():
             vqa_samples = {"image": img, "text_input": [question]}
             answers = model.predict_answers(vqa_samples, inference_method="generate")
 
-            col2.write("\n".join(answers), use_column_width=True)
+            col2.write("\n".join(answers))


### PR DESCRIPTION
streamlit `st.cache` is [deprecated](https://docs.streamlit.io/library/advanced-features/caching?ref=blog.streamlit.io#migrating-from-stcache) in favor of `st.cache_data` & `st.cache_resource`.
This PR updates that and removes invalid params. 
And fixes the type error with gradcam by passing numpy instead of torch