### PR TITLE
Correct the spelling from instuct to instruct

### DIFF
--- a/lavis/datasets/builders/caption_builder.py
+++ b/lavis/datasets/builders/caption_builder.py
@@ -30,8 +30,8 @@ from lavis.datasets.datasets.violin_dataset import (
     ViolinVideoCaptionInstructDataset,
     ViolinVideoCaptionEvalDataset
 )
-from lavis.datasets.datasets.valor_caption import VALORCaptionInstuctDataset, VALORCaptionEvalDataset, VALORCaptionDataset
-from lavis.datasets.datasets.vatex_captioning_datasets import VATEXCaptionInstuctDataset, VATEXCaptionEvalDataset, VATEXCaptionDataset
+from lavis.datasets.datasets.valor_caption import VALORCaptioninstructDataset, VALORCaptionEvalDataset, VALORCaptionDataset
+from lavis.datasets.datasets.vatex_captioning_datasets import VATEXCaptioninstructDataset, VATEXCaptionEvalDataset, VATEXCaptionDataset
 from lavis.datasets.datasets.vlep_dataset import VlepVideoDataset, VlepVideoInstructDataset, VlepVideoEvalDataset
 from lavis.datasets.datasets.vsr_datasets import VSRCaptionDataset, VSRCaptionInstructDataset, VSRCaptionEvalDataset
 from lavis.datasets.datasets.textcaps_datasets import TextCapsCapDataset, TextCapsCapInstructDataset, TextCapsCapEvalDataset
@@ -68,7 +68,7 @@ class Flickr30kCapInstructBuilder(BaseDatasetBuilder):
     train_dataset_cls = COCOCapInstructDataset
     eval_dataset_cls = COCOCapEvalDataset
     DATASET_CONFIG_DICT = {
-        "default": "configs/datasets/flickr30k/defaults_cap_instuct.yaml",
+        "default": "configs/datasets/flickr30k/defaults_cap_instruct.yaml",
     }
 
 @registry.register_builder("nocaps")
@@ -184,7 +184,7 @@ class MSVDCapInstructBuilder(BaseDatasetBuilder):
 
 @registry.register_builder("vatex_caption_instruct")
 class VATEXCapInstructBuilder(MultiModalDatasetBuilder):
-    train_dataset_cls = VATEXCaptionInstuctDataset
+    train_dataset_cls = VATEXCaptioninstructDataset
     eval_dataset_cls = VATEXCaptionEvalDataset
 
     DATASET_CONFIG_DICT = {
@@ -238,7 +238,7 @@ class VALORCaptionBuilder(MultiModalDatasetBuilder):
 
 @registry.register_builder("valor_mm_caption_instruct")
 class VALORCaptionInstructBuilder(MultiModalDatasetBuilder):
-    train_dataset_cls = VALORCaptionInstuctDataset
+    train_dataset_cls = VALORCaptioninstructDataset
     eval_dataset_cls = VALORCaptionEvalDataset
 
     DATASET_CONFIG_DICT = {

--- a/lavis/datasets/datasets/valor_caption.py
+++ b/lavis/datasets/datasets/valor_caption.py
@@ -79,7 +79,7 @@ class VALORCaptionEvalDataset(VALORCaptionDataset):
         return data
 
 
-class VALORCaptionInstuctDataset(VALORCaptionDataset):
+class VALORCaptionInstructDataset(VALORCaptionDataset):
     def __getitem__(self, index):
         data = super().__getitem__(index)
         if data != None:

--- a/lavis/datasets/datasets/vatex_captioning_datasets.py
+++ b/lavis/datasets/datasets/vatex_captioning_datasets.py
@@ -78,7 +78,7 @@ class VATEXCaptionEvalDataset(VATEXCaptionDataset):
         return data
 
 
-class VATEXCaptionInstuctDataset(VATEXCaptionDataset):
+class VATEXCaptionInstructDataset(VATEXCaptionDataset):
     def __getitem__(self, index):
         data = super().__getitem__(index)
         if data != None:


### PR DESCRIPTION
When finetuning on flickr30k, an error occurs because the code loads "configs/datasets/flickr30k/defaults_cap_instuct.yaml" according to the path defined in lavis/datasets/builders/caption_builder.py. Then, I find that the spelling of "instuct" is wrong and correct the spelling error.