### PR TITLE
Correct the spelling of "instuct"

### DIFF
--- a/lavis/datasets/builders/caption_builder.py
+++ b/lavis/datasets/builders/caption_builder.py
@@ -68,7 +68,7 @@ class Flickr30kCapInstructBuilder(BaseDatasetBuilder):
     train_dataset_cls = COCOCapInstructDataset
     eval_dataset_cls = COCOCapEvalDataset
     DATASET_CONFIG_DICT = {
-        "default": "configs/datasets/flickr30k/defaults_cap_instuct.yaml",
+        "default": "configs/datasets/flickr30k/defaults_cap_instruct.yaml",
     }
 
 @registry.register_builder("nocaps")


### PR DESCRIPTION
When finetuning on flickr30k, an error occurs because the code loads "configs/datasets/flickr30k/defaults_cap_instuct.yaml" according to the path defined in lavis/datasets/builders/caption_builder.py. Then, I find that the spelling of "instuct" is wrong and correct the spelling error.