### PR TITLE
Fix GradCAM ReLU placement per original paper

### DIFF
--- a/lavis/models/blip_models/blip_image_text_matching.py
+++ b/lavis/models/blip_models/blip_image_text_matching.py
@@ -175,11 +175,13 @@ def compute_gradcam(model, visual_input, text_input, tokenized_text, block_num=6
         # assume using vit with 576 num image patch
         cams = cams[:, :, :, 1:].reshape(visual_input.size(0), 12, -1, 24, 24) * mask
         grads = (
-            grads[:, :, :, 1:].clamp(0).reshape(visual_input.size(0), 12, -1, 24, 24)
+            grads[:, :, :, 1:].reshape(visual_input.size(0), 12, -1, 24, 24)
             * mask
         )
 
-        gradcams = cams * grads
+        # Apply ReLU to the final gradcam, not to intermediate gradients
+        # as per the original GradCAM paper
+        gradcams = (cams * grads).clamp(min=0)
         gradcam_list = []
 
         for ind in range(visual_input.size(0)):


### PR DESCRIPTION
## Summary
- Fixes incorrect ReLU placement in GradCAM computation
- Per the original GradCAM paper, ReLU should be applied to the final weighted combination of feature maps, not to intermediate gradients

## Changes
- Removed `.clamp(0)` from gradient computation on line 178
- Applied `.clamp(min=0)` to the final `gradcams = (cams * grads).clamp(min=0)` result

## Background
The GradCAM paper (Selvaraju et al., 2017) specifies that ReLU is applied to the final linear combination of weighted feature maps to obtain the class-discriminative localization map. Applying ReLU to gradients prematurely removes negative gradient information that may be relevant for the weighted combination.

## Test plan
- [x] Review GradCAM paper to confirm correct ReLU placement
- [x] Verify the fix aligns with standard GradCAM implementations

Fixes #789

🤖 Generated with [Claude Code](https://claude.com/claude-code)