### PR TITLE
Update transformers to fix CVE-2023-7018 security vulnerability

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ timm==0.4.12
 torch>=1.10.0
 torchvision
 tqdm
-transformers==4.33.2
+transformers>=4.36.0
 webdataset
 wheel
 torchaudio


### PR DESCRIPTION
## Summary
- Updates `transformers` from pinned `4.33.2` to `>=4.36.0`
- Addresses high severity vulnerability CVE-2023-7018
- See: https://nvd.nist.gov/vuln/detail/CVE-2023-7018

## Related Issue
Fixes #807

## Test plan
- [ ] Verify package installation works with updated version
- [ ] Run existing tests to ensure compatibility